### PR TITLE
Upgrade term 0.5 -> 0.6.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ keywords = [
 failure-bt = ["failure"]
 
 [dependencies]
-term = "0.5"
+term = "0.6.1"
 atty = "0.2"
 failure = { version = "0.1", optional = true }
 


### PR DESCRIPTION
Upgrade to latest term crate.

We ran into an issue where color-backtrace was brining in the older version of term that used `dirs` 1.0 instead of 2.0 which brought in `redox_users` which brought in an old version of `crossbeam` that uses the old `memoffset` 0.2.1 crate which has a security vournability reported in it: 

```
ID:	 RUSTSEC-2019-0011
Crate:	 memoffset
Version: 0.2.1
Date:	 2019-07-16
URL:	 https://github.com/Gilnaa/memoffset/issues/9#issuecomment-505461490
Title:	 Flaw in offset_of and span_of causes SIGILL, drops uninitialized memory of arbitrary type on panic in client code
Solution: upgrade to: >= 0.5.0
```