### PR TITLE
Fix "innacurate source info" link in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
   - This is done by adding `default-features = false` to the `Cargo.toml`
     dependency entry for `color-backtrace`
   - Disabling it reduces transitive dependencies from ~50 → ~10
-  - However, you'll pay for it with [inaccurate source info](bt-bug) on macOS
+  - However, you'll pay for it with [inaccurate source info](https://github.com/athre0z/color-backtrace/issues/2) on macOS
     and Linux
 
 #### Changed


### PR DESCRIPTION
Previously, this link was broken (pointing to what github thinks is a nonexistent branch). I've fixed the link to point to the same issue page the README does.