### PR TITLE
Remove output stream from settings & support formatting to String

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,24 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+#### Added
+- `PanicPrinter::format_trace_to_string`
+
 #### Changed
-- Added `out` argument to all public print functions
-  - This was previously part of the `Settings` struct, however this was
-    poor design, requiring the `Settings` to be mutable
+- Rename `Settings` -> `PanicPrinter`
+- Move `print_backtrace` -> `PanicPrinter::print_trace`
+- Move `print_panic_info` -> `PanicPrinter::print_panic_info`
+- Move `color_backtrace::failure::print_backtrace` -> 
+  `PanicPrinter::print_failure_trace`
+- The majority of old APIs have deprecated shims that forward calls to
+  their new place to ease porting
+- The `out` setting is no longer part of the `PanicPrinter` and instead
+  supplied as an argument to all functions that need it
   - The previous design forced `Sync + Send + 'static` constraints
     on any output stream since they are required when registering
     the panic handler, but are unnecessary when printing to strings
+  - As a bonus, all format and print functions no longer require
+    mutable access to the `PanicPrinter` instance
 
 ## [v0.3.0] (2019-11-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+#### Changed
+- Added `out` argument to all public print functions
+  - This was previously part of the `Settings` struct, however this was
+    poor design, requiring the `Settings` to be mutable
+  - The previous design forced `Sync + Send + 'static` constraints
+    on any output stream since they are required when registering
+    the panic handler, but are unnecessary when printing to strings
+
 ## [v0.3.0] (2019-11-12)
 
 #### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,23 +4,23 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 #### Added
-- `PanicPrinter::format_trace_to_string`
+- `BacktracePrinter::format_trace_to_string`
 
 #### Changed
-- Rename `Settings` -> `PanicPrinter`
-- Move `print_backtrace` -> `PanicPrinter::print_trace`
-- Move `print_panic_info` -> `PanicPrinter::print_panic_info`
-- Move `color_backtrace::failure::print_backtrace` -> 
-  `PanicPrinter::print_failure_trace`
+- Rename `Settings` -> `BacktracePrinter`
+- Move `print_backtrace` -> `BacktracePrinter::print_trace`
+- Move `print_panic_info` -> `BacktracePrinter::print_panic_info`
+- Move `color_backtrace::failure::print_backtrace` ->
+  `BacktracePrinter::print_failure_trace`
 - The majority of old APIs have deprecated shims that forward calls to
   their new place to ease porting
-- The `out` setting is no longer part of the `PanicPrinter` and instead
+- The `out` setting is no longer part of the `BacktracePrinter` and instead
   supplied as an argument to all functions that need it
   - The previous design forced `Sync + Send + 'static` constraints
     on any output stream since they are required when registering
     the panic handler, but are unnecessary when printing to strings
   - As a bonus, all format and print functions no longer require
-    mutable access to the `PanicPrinter` instance
+    mutable access to the `BacktracePrinter` instance
 
 ## [v0.3.0] (2019-11-12)
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,11 @@ color_backtrace::install();
 
 If you want to customize some settings, you can instead do:
 ```rust
-use color_backtrace::{install_with_settings, Settings};
-install_with_settings(Settings::new().message("Custom message!"));
+use color_backtrace::{default_output_stream, install_with_settings, Settings};
+install_with_settings(
+    Settings::new().message("Custom message!"),
+    default_output_stream(),
+);
 ```
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -27,11 +27,8 @@ color_backtrace::install();
 
 If you want to customize some settings, you can instead do:
 ```rust
-use color_backtrace::{default_output_stream, install_with_settings, Settings};
-install_with_settings(
-    Settings::new().message("Custom message!"),
-    default_output_stream(),
-);
+use color_backtrace::{default_output_stream, PanicPrinter};
+PanicPrinter::new().message("Custom message!").install(default_output_stream());
 ```
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ color_backtrace::install();
 
 If you want to customize some settings, you can instead do:
 ```rust
-use color_backtrace::{default_output_stream, PanicPrinter};
-PanicPrinter::new().message("Custom message!").install(default_output_stream());
+use color_backtrace::{default_output_stream, BacktracePrinter};
+BacktracePrinter::new().message("Custom message!").install(default_output_stream());
 ```
 
 ### Features

--- a/examples/custom_message.rs
+++ b/examples/custom_message.rs
@@ -1,5 +1,5 @@
 fn main() {
-    use color_backtrace::{default_output_stream, install_with_settings, Settings};
-    install_with_settings(Settings::new().message("Custom message!"));
+    use color_backtrace::PanicPrinter;
+    PanicPrinter::new().message("Custom message!").install();
     assert_eq!(1, 2);
 }

--- a/examples/custom_message.rs
+++ b/examples/custom_message.rs
@@ -1,5 +1,8 @@
 fn main() {
-    use color_backtrace::{install_with_settings, Settings};
-    install_with_settings(Settings::new().message("Custom message!"));
+    use color_backtrace::{default_output_stream, install_with_settings, Settings};
+    install_with_settings(
+        Settings::new().message("Custom message!"),
+        default_output_stream(),
+    );
     assert_eq!(1, 2);
 }

--- a/examples/custom_message.rs
+++ b/examples/custom_message.rs
@@ -1,7 +1,7 @@
-use color_backtrace::{default_output_stream, PanicPrinter};
+use color_backtrace::{default_output_stream, BacktracePrinter};
 
 fn main() {
-    PanicPrinter::new()
+    BacktracePrinter::new()
         .message("Custom message!")
         .install(default_output_stream());
     assert_eq!(1, 2);

--- a/examples/custom_message.rs
+++ b/examples/custom_message.rs
@@ -1,5 +1,8 @@
+use color_backtrace::{default_output_stream, PanicPrinter};
+
 fn main() {
-    use color_backtrace::PanicPrinter;
-    PanicPrinter::new().message("Custom message!").install();
+    PanicPrinter::new()
+        .message("Custom message!")
+        .install(default_output_stream());
     assert_eq!(1, 2);
 }

--- a/examples/custom_message.rs
+++ b/examples/custom_message.rs
@@ -1,8 +1,5 @@
 fn main() {
     use color_backtrace::{default_output_stream, install_with_settings, Settings};
-    install_with_settings(
-        Settings::new().message("Custom message!"),
-        default_output_stream(),
-    );
+    install_with_settings(Settings::new().message("Custom message!"));
     assert_eq!(1, 2);
 }

--- a/examples/failure.rs
+++ b/examples/failure.rs
@@ -1,4 +1,4 @@
-use color_backtrace::{failure::print_backtrace, Settings};
+use color_backtrace::{failure::print_backtrace, PanicPrinter};
 use failure::{format_err, Fallible};
 
 fn calc_things() -> Fallible<()> {
@@ -13,7 +13,7 @@ fn main() -> Result<(), std::io::Error> {
     if let Err(e) = do_some_stuff() {
         // oh noez!
         unsafe {
-            print_backtrace(&e.backtrace(), &mut Settings::new())?;
+            print_backtrace(&e.backtrace(), &mut PanicPrinter::new())?;
         }
     }
 

--- a/examples/failure.rs
+++ b/examples/failure.rs
@@ -1,4 +1,4 @@
-use color_backtrace::{default_output_stream, PanicPrinter};
+use color_backtrace::{default_output_stream, BacktracePrinter};
 use failure::{format_err, Fallible};
 
 fn calc_things() -> Fallible<()> {
@@ -13,7 +13,7 @@ fn main() -> Result<(), std::io::Error> {
     if let Err(e) = do_some_stuff() {
         // oh noez!
         unsafe {
-            PanicPrinter::new()
+            BacktracePrinter::new()
                 .print_failure_trace(&e.backtrace(), &mut default_output_stream())?;
         }
     }

--- a/examples/failure.rs
+++ b/examples/failure.rs
@@ -1,4 +1,4 @@
-use color_backtrace::{failure::print_backtrace, PanicPrinter};
+use color_backtrace::{default_output_stream, PanicPrinter};
 use failure::{format_err, Fallible};
 
 fn calc_things() -> Fallible<()> {
@@ -13,7 +13,8 @@ fn main() -> Result<(), std::io::Error> {
     if let Err(e) = do_some_stuff() {
         // oh noez!
         unsafe {
-            print_backtrace(&e.backtrace(), &mut PanicPrinter::new())?;
+            PanicPrinter::new()
+                .print_failure_trace(&e.backtrace(), &mut default_output_stream())?;
         }
     }
 

--- a/examples/fmt_to_string.rs
+++ b/examples/fmt_to_string.rs
@@ -1,0 +1,19 @@
+use color_backtrace::{format_backtrace, Settings};
+
+fn main() -> Result<(), std::io::Error> {
+    let trace = backtrace::Backtrace::new();
+    let settings = Settings::default();
+    let str = format_backtrace(&trace, &settings)?;
+
+    if cfg!(windows) {
+        println!(
+            "Warning: on Windows, you'll have to enable VT100 \
+             printing for your app in order for this to work \
+             correctly. This example doesn't do this."
+        );
+    }
+
+    println!("{}", str);
+
+    Ok(())
+}

--- a/examples/fmt_to_string.rs
+++ b/examples/fmt_to_string.rs
@@ -1,9 +1,9 @@
-use color_backtrace::{format_backtrace, Settings};
+use color_backtrace::PanicPrinter;
 
 fn main() -> Result<(), std::io::Error> {
     let trace = backtrace::Backtrace::new();
-    let settings = Settings::default();
-    let str = format_backtrace(&trace, &settings)?;
+    let printer = PanicPrinter::default();
+    let str = printer.print_trace_to_string(&trace)?;
 
     if cfg!(windows) {
         println!(

--- a/examples/fmt_to_string.rs
+++ b/examples/fmt_to_string.rs
@@ -1,9 +1,9 @@
-use color_backtrace::PanicPrinter;
+use color_backtrace::BacktracePrinter;
 
 fn main() -> Result<(), std::io::Error> {
     let trace = backtrace::Backtrace::new();
-    let printer = PanicPrinter::default();
-    let str = printer.print_trace_to_string(&trace)?;
+    let printer = BacktracePrinter::default();
+    let str = printer.format_trace_to_string(&trace)?;
 
     if cfg!(windows) {
         println!(

--- a/examples/force_color.rs
+++ b/examples/force_color.rs
@@ -21,8 +21,7 @@ fn fn1() {
 fn main() {
     use color_backtrace::{install_with_settings, Settings};
     let out = termcolor::StandardStream::stderr(termcolor::ColorChoice::Always);
-    let settings = Settings::new().output_stream(Box::new(out));
-    install_with_settings(settings);
+    install_with_settings(Settings::new(), out);
 
     fn1();
 }

--- a/examples/force_color.rs
+++ b/examples/force_color.rs
@@ -19,9 +19,9 @@ fn fn1() {
 }
 
 fn main() {
-    use color_backtrace::{termcolor::StandardStream, PanicPrinter};
+    use color_backtrace::{termcolor::StandardStream, BacktracePrinter};
     let out = StandardStream::stderr(termcolor::ColorChoice::Always);
-    PanicPrinter::new().install(out);
+    BacktracePrinter::new().install(out);
 
     fn1();
 }

--- a/examples/force_color.rs
+++ b/examples/force_color.rs
@@ -19,8 +19,9 @@ fn fn1() {
 }
 
 fn main() {
-    use color_backtrace::{install_with_settings, Settings};
-    install_with_settings(Settings::new());
+    use color_backtrace::{termcolor::StandardStream, PanicPrinter};
+    let out = StandardStream::stderr(termcolor::ColorChoice::Always);
+    PanicPrinter::new().install(out);
 
     fn1();
 }

--- a/examples/force_color.rs
+++ b/examples/force_color.rs
@@ -20,8 +20,7 @@ fn fn1() {
 
 fn main() {
     use color_backtrace::{install_with_settings, Settings};
-    let out = termcolor::StandardStream::stderr(termcolor::ColorChoice::Always);
-    install_with_settings(Settings::new(), out);
+    install_with_settings(Settings::new());
 
     fn1();
 }

--- a/src/failure.rs
+++ b/src/failure.rs
@@ -37,11 +37,11 @@ pub unsafe fn backdoortrace(_opaque: &failure::Backtrace) -> Option<&backtrace::
 
 #[deprecated(
     since = "0.4",
-    note = "Use `PanicPrinter::print_failure_trace` instead."
+    note = "Use `BacktracePrinter::print_failure_trace` instead."
 )]
 pub unsafe fn print_backtrace(
     trace: &failure::Backtrace,
-    printer: &crate::PanicPrinter,
+    printer: &crate::BacktracePrinter,
 ) -> crate::IOResult {
     printer.print_failure_trace(trace, &mut default_output_stream())
 }
@@ -55,7 +55,7 @@ mod tests {
         std::env::set_var("RUST_BACKTRACE", "full");
 
         let e = failure::format_err!("arbitrary error :)");
-        let printer = crate::PanicPrinter::new();
+        let printer = crate::BacktracePrinter::new();
         unsafe {
             printer
                 .print_failure_trace(e.backtrace(), &mut default_output_stream())

--- a/src/failure.rs
+++ b/src/failure.rs
@@ -55,23 +55,11 @@ mod tests {
         std::env::set_var("RUST_BACKTRACE", "full");
 
         let e = failure::format_err!("arbitrary error :)");
-        let mut settings = crate::Settings::default();
+        let printer = crate::PanicPrinter::new();
         unsafe {
-            print_backtrace(e.backtrace(), &mut settings).unwrap();
-        }
-    }
-
-    #[ignore]
-    #[test]
-    fn without_envvar() {
-        if std::env::var("RUST_BACKTRACE").is_ok() {
-            std::env::remove_var("RUST_BACKTRACE");
-        }
-
-        let e = failure::format_err!("arbitrary error :)");
-        let mut settings = crate::Settings::default();
-        unsafe {
-            print_backtrace(e.backtrace(), &mut settings).unwrap();
+            printer
+                .print_failure_trace(e.backtrace(), &mut default_output_stream())
+                .unwrap();
         }
     }
 }

--- a/src/failure.rs
+++ b/src/failure.rs
@@ -1,5 +1,7 @@
 //! Temporary hack to allow printing of `failure::Backtrace` objects.
 
+use crate::default_output_stream;
+
 struct FakeBacktrace {
     internal: FakeInternalBacktrace,
 }
@@ -33,19 +35,15 @@ pub unsafe fn backdoortrace(_opaque: &failure::Backtrace) -> Option<&backtrace::
     None
 }
 
-/// Extracts the internal `backtrace::Backtrace` from a `failure::Backtrace` and prints it, if one
-/// exists. Prints that a backtrace was not capture if one is not found.
+#[deprecated(
+    since = "0.4",
+    note = "Use `PanicPrinter::print_failure_trace` instead."
+)]
 pub unsafe fn print_backtrace(
     trace: &failure::Backtrace,
-    settings: &mut crate::Settings,
+    printer: &crate::PanicPrinter,
 ) -> crate::IOResult {
-    let internal = backdoortrace(trace);
-
-    if let Some(internal) = internal {
-        super::print_backtrace(internal, settings)
-    } else {
-        writeln!(settings.out, "<failure backtrace not captured>")
-    }
+    printer.print_failure_trace(trace, &mut default_output_stream())
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,9 +25,9 @@
 //!
 //! If you want to customize some settings, you can instead do:
 //! ```rust
-//! use color_backtrace::{install_with_settings, default_output_stream, Settings};
+//! use color_backtrace::{install_with_settings, default_output_stream, PanicPrinter};
 //! install_with_settings(
-//!     Settings::new().message("Custom message!"),
+//!     PanicPrinter::new().message("Custom message!"),
 //!     default_output_stream(),
 //! );
 //! ```
@@ -39,7 +39,6 @@
 //! [medium](Verbosity::Medium) and `RUST_BACKTRACE=full` to
 //! [full](Verbosity::Full) verbosity levels.
 
-use std::fmt;
 use std::fs::File;
 use std::io::{BufRead, BufReader, ErrorKind};
 use std::panic::PanicInfo;
@@ -88,7 +87,21 @@ impl Verbosity {
 // [Panic handler and install logic]                                                              //
 // ============================================================================================== //
 
-// TODO: documentation
+/// Install the `color_backtrace` handler with default settings.
+///
+/// This currently is a convenience shortcut for writing
+///
+/// ```rust
+/// color_backtrace::PanicPrinter::default().install()
+/// ```
+pub fn install() {
+    PanicPrinter::default().install();
+}
+
+/// Create the default output stream.
+///
+/// If stderr is attached to a tty, this is a colorized stderr, else it's
+/// a plain (colorless) stderr.
 pub fn default_output_stream() -> Box<StandardStream> {
     Box::new(StandardStream::stderr(if atty::is(atty::Stream::Stderr) {
         ColorChoice::Always
@@ -100,14 +113,17 @@ pub fn default_output_stream() -> Box<StandardStream> {
 /// Create a `color_backtrace` panic handler.
 ///
 /// This can be used if you want to combine the handler with other handlers.
+#[deprecated(
+    since = "0.4",
+    note = "Use `PanicPrinter::into_panic_handler()` instead."
+)]
 pub fn create_panic_handler(
-    settings: Settings,
-    out: impl WriteColor + Sync + Send + 'static,
+    printer: PanicPrinter,
 ) -> Box<dyn Fn(&PanicInfo<'_>) + 'static + Sync + Send> {
-    let out_stream_mutex = Mutex::new(out);
+    let out_stream_mutex = Mutex::new(default_output_stream());
     Box::new(move |pi| {
         let mut lock = out_stream_mutex.lock().unwrap();
-        if let Err(e) = print_panic_info(pi, &mut *lock, &settings) {
+        if let Err(e) = printer.print_panic_info(pi, &mut *lock) {
             // Panicking while handling a panic would send us into a deadlock,
             // so we just print the error to stderr instead.
             eprintln!("Error while printing panic: {:?}", e);
@@ -115,16 +131,10 @@ pub fn create_panic_handler(
     })
 }
 
-/// Install the `color_backtrace` handler with default settings.
-///
-/// Convenience method that just calls
-pub fn install() {
-    install_with_settings(Settings::default(), default_output_stream())
-}
-
 /// Install the `color_backtrace` handler with custom settings.
-pub fn install_with_settings(settings: Settings, out: impl WriteColor + Send + Sync + 'static) {
-    std::panic::set_hook(create_panic_handler(settings, out))
+#[deprecated(since = "0.4", note = "Use `PanicPrinter::install()` instead.")]
+pub fn install_with_settings(printer: PanicPrinter) {
+    std::panic::set_hook(printer.into_panic_handler(default_output_stream()))
 }
 
 // ============================================================================================== //
@@ -238,7 +248,7 @@ impl Frame {
         false
     }
 
-    fn print_source_if_avail(&self, mut out: impl WriteColor, s: &Settings) -> IOResult {
+    fn print_source_if_avail(&self, mut out: impl WriteColor, s: &PanicPrinter) -> IOResult {
         let (lineno, filename) = match (self.lineno, self.filename.as_ref()) {
             (Some(a), Some(b)) => (a, b),
             // Without a line number and file name, we can't sensibly proceed.
@@ -269,7 +279,7 @@ impl Frame {
         Ok(())
     }
 
-    fn print(&self, i: usize, out: &mut impl WriteColor, s: &Settings) -> IOResult {
+    fn print(&self, i: usize, out: &mut impl WriteColor, s: &PanicPrinter) -> IOResult {
         let is_dependency_code = self.is_dependency_code();
 
         // Print frame index.
@@ -328,7 +338,7 @@ impl Frame {
 }
 
 // ============================================================================================== //
-// [Settings]                                                                                     //
+// [PanicPrinter]                                                                                     //
 // ============================================================================================== //
 
 /// Color scheme definition.
@@ -381,15 +391,18 @@ impl Default for ColorScheme {
     }
 }
 
-/// Configuration for panic printing.
-pub struct Settings {
+#[deprecated(since = "0.4", note = "Use `PanicPrinter` instead.")]
+pub type Settings = PanicPrinter;
+
+/// Pretty-printer for backtraces and [`PanicInfo`](PanicInfo) structs.
+pub struct PanicPrinter {
     message: String,
     verbosity: Verbosity,
     strip_function_hash: bool,
     colors: ColorScheme,
 }
 
-impl Default for Settings {
+impl Default for PanicPrinter {
     fn default() -> Self {
         Self {
             verbosity: Verbosity::from_env(),
@@ -400,19 +413,9 @@ impl Default for Settings {
     }
 }
 
-impl fmt::Debug for Settings {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.debug_struct("Settings")
-            .field("message", &self.message)
-            .field("verbosity", &self.verbosity)
-            .field("strip_function_hash_part", &self.strip_function_hash)
-            .field("colors", &self.colors)
-            .finish()
-    }
-}
-
-impl Settings {
-    /// Alias for `Settings::default`.
+/// Builder functions.
+impl PanicPrinter {
+    /// Alias for `PanicPrinter::default`.
     pub fn new() -> Self {
         Self::default()
     }
@@ -454,141 +457,159 @@ impl Settings {
 // [Panic printing]                                                                               //
 // ============================================================================================== //
 
-/// Pretty-prints a [`backtrace::Backtrace`](backtrace::Backtrace) according the
-/// the given settings.
-pub fn print_backtrace(
-    trace: &backtrace::Backtrace,
-    out: &mut impl WriteColor,
-    settings: &Settings,
-) -> IOResult {
-    let s = settings;
-    writeln!(out, "{:━^80}", " BACKTRACE ")?;
+impl PanicPrinter {
+    /// Install the `color_backtrace` handler with default settings.
+    pub fn install(self) {
+        std::panic::set_hook(self.into_panic_handler(default_output_stream()))
+    }
 
-    // Collect frame info.
-    let frames: Vec<_> = trace
-        .frames()
-        .iter()
-        .flat_map(|frame| frame.symbols())
-        .map(|sym| Frame {
-            name: sym.name().map(|x| x.to_string()),
-            lineno: sym.lineno(),
-            filename: sym.filename().map(|x| x.into()),
+    /// Create a `color_backtrace` panic handler from this panic printer.
+    ///
+    /// This can be used if you want to combine the handler with other handlers.
+    pub fn into_panic_handler(
+        self,
+        out: impl WriteColor + Sync + Send + 'static,
+    ) -> Box<dyn Fn(&PanicInfo<'_>) + 'static + Sync + Send> {
+        let out_stream_mutex = Mutex::new(out);
+        Box::new(move |pi| {
+            let mut lock = out_stream_mutex.lock().unwrap();
+            if let Err(e) = self.print_panic_info(pi, &mut *lock) {
+                // Panicking while handling a panic would send us into a deadlock,
+                // so we just print the error to stderr instead.
+                eprintln!("Error while printing panic: {:?}", e);
+            }
         })
-        .collect();
-
-    // Try to find where the interesting part starts...
-    let top_cutoff = frames
-        .iter()
-        .rposition(Frame::is_post_panic_code)
-        .map(|x| x + 1)
-        .unwrap_or(0);
-
-    // Try to find where language init frames start ...
-    let bottom_cutoff = frames
-        .iter()
-        .position(Frame::is_runtime_init_code)
-        .unwrap_or_else(|| frames.len());
-
-    if top_cutoff != 0 {
-        let text = format!("({} post panic frames hidden)", top_cutoff);
-        out.set_color(&s.colors.frames_omitted_msg)?;
-        writeln!(out, "{:^80}", text)?;
-        out.reset()?;
     }
 
-    // Turn them into `Frame` objects and print them.
-    let num_frames = frames.len();
-    let frames = frames
-        .into_iter()
-        .skip(top_cutoff)
-        .take(bottom_cutoff - top_cutoff)
-        .zip(top_cutoff..);
+    /// Pretty-prints a [`backtrace::Backtrace`](backtrace::Backtrace) to an output stream.
+    pub fn print_trace(&self, trace: &backtrace::Backtrace, out: &mut impl WriteColor) -> IOResult {
+        writeln!(out, "{:━^80}", " BACKTRACE ")?;
 
-    // Print surviving frames.
-    for (frame, i) in frames {
-        frame.print(i, out, s)?;
-    }
+        // Collect frame info.
+        let frames: Vec<_> = trace
+            .frames()
+            .iter()
+            .flat_map(|frame| frame.symbols())
+            .map(|sym| Frame {
+                name: sym.name().map(|x| x.to_string()),
+                lineno: sym.lineno(),
+                filename: sym.filename().map(|x| x.into()),
+            })
+            .collect();
 
-    if bottom_cutoff != num_frames {
-        let text = format!(
-            "({} runtime init frames hidden)",
-            num_frames - bottom_cutoff
-        );
-        out.set_color(&s.colors.frames_omitted_msg)?;
-        writeln!(out, "{:^80}", text)?;
-        out.reset()?;
-    }
+        // Try to find where the interesting part starts...
+        let top_cutoff = frames
+            .iter()
+            .rposition(Frame::is_post_panic_code)
+            .map(|x| x + 1)
+            .unwrap_or(0);
 
-    Ok(())
-}
+        // Try to find where language init frames start ...
+        let bottom_cutoff = frames
+            .iter()
+            .position(Frame::is_runtime_init_code)
+            .unwrap_or_else(|| frames.len());
 
-// TODO: documentation
-pub fn format_backtrace(trace: &backtrace::Backtrace, settings: &Settings) -> IOResult<String> {
-    let mut ansi = Ansi::new(vec![]);
-    print_backtrace(trace, &mut ansi, settings)?;
-    Ok(String::from_utf8(ansi.into_inner()).unwrap())
-}
-
-/// Pretty-prints a [`PanicInfo`](PanicInfo) struct according to the given
-/// settings.
-pub fn print_panic_info(pi: &PanicInfo, out: &mut impl WriteColor, s: &Settings) -> IOResult {
-    out.set_color(&s.colors.header)?;
-    writeln!(out, "{}", s.message)?;
-    out.reset()?;
-
-    // Print panic message.
-    let payload = pi
-        .payload()
-        .downcast_ref::<String>()
-        .map(String::as_str)
-        .or_else(|| pi.payload().downcast_ref::<&str>().cloned())
-        .unwrap_or("<non string panic payload>");
-
-    write!(out, "Message:  ")?;
-    out.set_color(&s.colors.msg_loc_prefix)?;
-    writeln!(out, "{}", payload)?;
-    out.reset()?;
-
-    // If known, print panic location.
-    write!(out, "Location: ")?;
-    if let Some(loc) = pi.location() {
-        out.set_color(&s.colors.src_loc)?;
-        write!(out, "{}", loc.file())?;
-        out.set_color(&s.colors.src_loc_separator)?;
-        write!(out, ":")?;
-        out.set_color(&s.colors.src_loc)?;
-        writeln!(out, "{}", loc.line())?;
-        out.reset()?;
-    } else {
-        writeln!(out, "<unknown>")?;
-    }
-
-    // Print some info on how to increase verbosity.
-    if s.verbosity == Verbosity::Minimal {
-        write!(out, "\nBacktrace omitted. Run with ")?;
-        out.set_color(&s.colors.env_var)?;
-        write!(out, "RUST_BACKTRACE=1")?;
-        out.reset()?;
-        writeln!(out, " environment variable to display it.")?;
-    }
-    if s.verbosity <= Verbosity::Medium {
-        if s.verbosity == Verbosity::Medium {
-            // If exactly medium, no newline was printed before.
-            writeln!(out)?;
+        if top_cutoff != 0 {
+            let text = format!("({} post panic frames hidden)", top_cutoff);
+            out.set_color(&self.colors.frames_omitted_msg)?;
+            writeln!(out, "{:^80}", text)?;
+            out.reset()?;
         }
 
-        write!(out, "Run with ")?;
-        out.set_color(&s.colors.env_var)?;
-        write!(out, "RUST_BACKTRACE=full")?;
+        // Turn them into `Frame` objects and print them.
+        let num_frames = frames.len();
+        let frames = frames
+            .into_iter()
+            .skip(top_cutoff)
+            .take(bottom_cutoff - top_cutoff)
+            .zip(top_cutoff..);
+
+        // Print surviving frames.
+        for (frame, i) in frames {
+            frame.print(i, out, self)?;
+        }
+
+        if bottom_cutoff != num_frames {
+            let text = format!(
+                "({} runtime init frames hidden)",
+                num_frames - bottom_cutoff
+            );
+            out.set_color(&self.colors.frames_omitted_msg)?;
+            writeln!(out, "{:^80}", text)?;
+            out.reset()?;
+        }
+
+        Ok(())
+    }
+
+    // TODO: documentation
+    pub fn print_trace_to_string(&self, trace: &backtrace::Backtrace) -> IOResult<String> {
+        let mut ansi = Ansi::new(vec![]);
+        self.print_trace(trace, &mut ansi)?;
+        Ok(String::from_utf8(ansi.into_inner()).unwrap())
+    }
+
+    /// Pretty-prints a [`PanicInfo`](PanicInfo) struct to an output stream.
+    pub fn print_panic_info(&self, pi: &PanicInfo, out: &mut impl WriteColor) -> IOResult {
+        out.set_color(&self.colors.header)?;
+        writeln!(out, "{}", self.message)?;
         out.reset()?;
-        writeln!(out, " to include source snippets.")?;
-    }
 
-    if s.verbosity >= Verbosity::Medium {
-        print_backtrace(&backtrace::Backtrace::new(), out, s)?;
-    }
+        // Print panic message.
+        let payload = pi
+            .payload()
+            .downcast_ref::<String>()
+            .map(String::as_str)
+            .or_else(|| pi.payload().downcast_ref::<&str>().cloned())
+            .unwrap_or("<non string panic payload>");
 
-    Ok(())
+        write!(out, "Message:  ")?;
+        out.set_color(&self.colors.msg_loc_prefix)?;
+        writeln!(out, "{}", payload)?;
+        out.reset()?;
+
+        // If known, print panic location.
+        write!(out, "Location: ")?;
+        if let Some(loc) = pi.location() {
+            out.set_color(&self.colors.src_loc)?;
+            write!(out, "{}", loc.file())?;
+            out.set_color(&self.colors.src_loc_separator)?;
+            write!(out, ":")?;
+            out.set_color(&self.colors.src_loc)?;
+            writeln!(out, "{}", loc.line())?;
+            out.reset()?;
+        } else {
+            writeln!(out, "<unknown>")?;
+        }
+
+        // Print some info on how to increase verbosity.
+        if self.verbosity == Verbosity::Minimal {
+            write!(out, "\nBacktrace omitted. Run with ")?;
+            out.set_color(&self.colors.env_var)?;
+            write!(out, "RUST_BACKTRACE=1")?;
+            out.reset()?;
+            writeln!(out, " environment variable to display it.")?;
+        }
+        if self.verbosity <= Verbosity::Medium {
+            if self.verbosity == Verbosity::Medium {
+                // If exactly medium, no newline was printed before.
+                writeln!(out)?;
+            }
+
+            write!(out, "Run with ")?;
+            out.set_color(&self.colors.env_var)?;
+            write!(out, "RUST_BACKTRACE=full")?;
+            out.reset()?;
+            writeln!(out, " to include source snippets.")?;
+        }
+
+        if self.verbosity >= Verbosity::Medium {
+            self.print_trace(&backtrace::Backtrace::new(), out)?;
+        }
+
+        Ok(())
+    }
 }
 
 // ============================================================================================== //

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,8 +25,8 @@
 //!
 //! If you want to customize some settings, you can instead do:
 //! ```rust
-//! use color_backtrace::{default_output_stream, PanicPrinter};
-//! PanicPrinter::new().message("Custom message!").install(default_output_stream());
+//! use color_backtrace::{default_output_stream, BacktracePrinter};
+//! BacktracePrinter::new().message("Custom message!").install(default_output_stream());
 //! ```
 //!
 //! ### Controlling verbosity
@@ -84,16 +84,16 @@ impl Verbosity {
 // [Panic handler and install logic]                                                              //
 // ============================================================================================== //
 
-/// Install a `PanicPrinter` handler with `::default()` settings.
+/// Install a `BacktracePrinter` handler with `::default()` settings.
 ///
 /// This currently is a convenience shortcut for writing
 ///
 /// ```rust
-/// use color_backtrace::{PanicPrinter, default_output_stream};
-/// PanicPrinter::default().install(default_output_stream())
+/// use color_backtrace::{BacktracePrinter, default_output_stream};
+/// BacktracePrinter::default().install(default_output_stream())
 /// ```
 pub fn install() {
-    PanicPrinter::default().install(default_output_stream());
+    BacktracePrinter::default().install(default_output_stream());
 }
 
 /// Create the default output stream.
@@ -110,10 +110,10 @@ pub fn default_output_stream() -> Box<StandardStream> {
 
 #[deprecated(
     since = "0.4",
-    note = "Use `PanicPrinter::into_panic_handler()` instead."
+    note = "Use `BacktracePrinter::into_panic_handler()` instead."
 )]
 pub fn create_panic_handler(
-    printer: PanicPrinter,
+    printer: BacktracePrinter,
 ) -> Box<dyn Fn(&PanicInfo<'_>) + 'static + Sync + Send> {
     let out_stream_mutex = Mutex::new(default_output_stream());
     Box::new(move |pi| {
@@ -126,8 +126,8 @@ pub fn create_panic_handler(
     })
 }
 
-#[deprecated(since = "0.4", note = "Use `PanicPrinter::install()` instead.")]
-pub fn install_with_settings(printer: PanicPrinter) {
+#[deprecated(since = "0.4", note = "Use `BacktracePrinter::install()` instead.")]
+pub fn install_with_settings(printer: BacktracePrinter) {
     std::panic::set_hook(printer.into_panic_handler(default_output_stream()))
 }
 
@@ -242,7 +242,7 @@ impl Frame {
         false
     }
 
-    fn print_source_if_avail(&self, mut out: impl WriteColor, s: &PanicPrinter) -> IOResult {
+    fn print_source_if_avail(&self, mut out: impl WriteColor, s: &BacktracePrinter) -> IOResult {
         let (lineno, filename) = match (self.lineno, self.filename.as_ref()) {
             (Some(a), Some(b)) => (a, b),
             // Without a line number and file name, we can't sensibly proceed.
@@ -273,7 +273,7 @@ impl Frame {
         Ok(())
     }
 
-    fn print(&self, i: usize, out: &mut impl WriteColor, s: &PanicPrinter) -> IOResult {
+    fn print(&self, i: usize, out: &mut impl WriteColor, s: &BacktracePrinter) -> IOResult {
         let is_dependency_code = self.is_dependency_code();
 
         // Print frame index.
@@ -332,7 +332,7 @@ impl Frame {
 }
 
 // ============================================================================================== //
-// [PanicPrinter]                                                                                     //
+// [BacktracePrinter]                                                                                     //
 // ============================================================================================== //
 
 /// Color scheme definition.
@@ -385,18 +385,18 @@ impl Default for ColorScheme {
     }
 }
 
-#[deprecated(since = "0.4", note = "Use `PanicPrinter` instead.")]
-pub type Settings = PanicPrinter;
+#[deprecated(since = "0.4", note = "Use `BacktracePrinter` instead.")]
+pub type Settings = BacktracePrinter;
 
 /// Pretty-printer for backtraces and [`PanicInfo`](PanicInfo) structs.
-pub struct PanicPrinter {
+pub struct BacktracePrinter {
     message: String,
     verbosity: Verbosity,
     strip_function_hash: bool,
     colors: ColorScheme,
 }
 
-impl Default for PanicPrinter {
+impl Default for BacktracePrinter {
     fn default() -> Self {
         Self {
             verbosity: Verbosity::from_env(),
@@ -408,8 +408,8 @@ impl Default for PanicPrinter {
 }
 
 /// Builder functions.
-impl PanicPrinter {
-    /// Alias for `PanicPrinter::default`.
+impl BacktracePrinter {
+    /// Alias for `BacktracePrinter::default`.
     pub fn new() -> Self {
         Self::default()
     }
@@ -448,7 +448,7 @@ impl PanicPrinter {
 }
 
 /// Routines for putting the panic printer to use.
-impl PanicPrinter {
+impl BacktracePrinter {
     /// Install the `color_backtrace` handler with default settings.
     ///
     /// Output streams can be created via `default_output_stream()` or
@@ -629,13 +629,16 @@ impl PanicPrinter {
 // [Deprecated routines for backward compat]                                                      //
 // ============================================================================================== //
 
-#[deprecated(since = "0.4", note = "Use `PanicPrinter::print_trace` instead`")]
-pub fn print_backtrace(trace: &backtrace::Backtrace, s: &mut PanicPrinter) -> IOResult {
+#[deprecated(since = "0.4", note = "Use `BacktracePrinter::print_trace` instead`")]
+pub fn print_backtrace(trace: &backtrace::Backtrace, s: &mut BacktracePrinter) -> IOResult {
     s.print_trace(trace, &mut default_output_stream())
 }
 
-#[deprecated(since = "0.4", note = "Use `PanicPrinter::print_panic_info` instead`")]
-pub fn print_panic_info(pi: &PanicInfo, s: &mut PanicPrinter) -> IOResult {
+#[deprecated(
+    since = "0.4",
+    note = "Use `BacktracePrinter::print_panic_info` instead`"
+)]
+pub fn print_panic_info(pi: &PanicInfo, s: &mut BacktracePrinter) -> IOResult {
     s.print_panic_info(pi, &mut default_output_stream())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ use std::io::{BufRead, BufReader, ErrorKind};
 use std::panic::PanicInfo;
 use std::path::PathBuf;
 use std::sync::Mutex;
-use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
+use termcolor::{Ansi, Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 
 #[cfg(feature = "failure-bt")]
 pub mod failure;
@@ -520,6 +520,13 @@ pub fn print_backtrace(
     }
 
     Ok(())
+}
+
+// TODO: documentation
+pub fn format_backtrace(trace: &backtrace::Backtrace, settings: &Settings) -> IOResult<String> {
+    let mut ansi = Ansi::new(vec![]);
+    print_backtrace(trace, &mut ansi, settings)?;
+    Ok(String::from_utf8(ansi.into_inner()).unwrap())
 }
 
 /// Pretty-prints a [`PanicInfo`](PanicInfo) struct according to the given


### PR DESCRIPTION
Fixes #27 and competes against #28.

This implementation keeps `termcolor` and adds `PanicPrinter::format_trace_to_string` instead of implementing `std::fmt::Formatter`, as well keeping support for older Windows versions mostly intact. The latter wasn't an explicit goal of this impl but comes as a bonus point of sticking with `termcolor`.

Since this change is interface-breaking anyways, I used this opportunity to refactor the public interface and added backward compatibility shims with deprecation notices wherever possible.

##

Quote from `CHANGELOG.md`
> #### Added
> - `PanicPrinter::format_trace_to_string`
> 
> #### Changed
> - Rename `Settings` -> `PanicPrinter`
> - Move `print_backtrace` -> `PanicPrinter::print_trace`
> - Move `print_panic_info` -> `PanicPrinter::print_panic_info`
> - Move `color_backtrace::failure::print_backtrace` -> 
>   `PanicPrinter::print_failure_trace`
> - The majority of old APIs have deprecated shims that forward calls to
>   their new place to ease porting
> - The `out` setting is no longer part of the `PanicPrinter` and instead
>   supplied as an argument to all functions that need it
>   - The previous design forced `Sync + Send + 'static` constraints
>     on any output stream since they are required when registering
>     the panic handler, but are unnecessary when printing to strings
>   - As a bonus, all format and print functions no longer require
>     mutable access to the `PanicPrinter` instance