### PR TITLE
Add re-export and example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,7 @@ btparse = { git = "https://github.com/yaahc/btparse.git", rev = "54f9ddb8c7c8f8e
 [[example]]
 name = "fmt_to_string"
 required-features = ["use-backtrace-crate"]
+
+[[example]]
+name = "fmt_to_string_std"
+required-features = ["use-btparse-crate"]

--- a/examples/fmt_to_string_std.rs
+++ b/examples/fmt_to_string_std.rs
@@ -1,0 +1,25 @@
+use color_backtrace::BacktracePrinter;
+
+fn main() -> Result<(), std::io::Error> {
+    // Start your trace
+    let trace = std::backtrace::Backtrace::force_capture();
+
+    // Do stuff...
+
+    // And print!
+    let bt = color_backtrace::btparse::deserialize(&trace).unwrap();
+    let printer = BacktracePrinter::default();
+    let str = printer.format_trace_to_string(&bt)?;
+
+    if cfg!(windows) {
+        println!(
+            "Warning: on Windows, you'll have to enable VT100 \
+             printing for your app in order for this to work \
+             correctly. This example doesn't do this."
+        );
+    }
+
+    println!("{}", str);
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,10 @@ use termcolor::{Ansi, Color, ColorChoice, ColorSpec, StandardStream, WriteColor}
 // Re-export termcolor so users don't have to depend on it themselves.
 pub use termcolor;
 
+// Re-export btparse as it has the deserialize function
+#[cfg(feature = "use-btparse-crate")]
+pub use btparse;
+
 // ============================================================================================== //
 // [Result / Error types]                                                                         //
 // ============================================================================================== //


### PR DESCRIPTION
Adding a re-export as the users shouldn't need to manually download the btparse crate to parse it

Added an example as well for the std backtrace (mostly to have a test)