### PR TITLE
Fix is_dependency_code for Windows

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -295,18 +295,15 @@ impl Frame {
             }
         }
 
-        const FILE_PREFIXES: &[&str] = &[
-            "/rustc",
-            "src/libstd",
-            "src/libpanic_unwind",
-            "src/libtest",
-            env!("CARGO_HOME"),
-        ];
+        const FILE_PREFIXES: &[&str] =
+            &["/rustc", "src/libstd", "src/libpanic_unwind", "src/libtest"];
 
         // Inspect filename.
-        self.filename
-            .as_deref()
-            .is_some_and(|filename| FILE_PREFIXES.iter().any(|x| filename.starts_with(x)))
+        self.filename.as_deref().is_some_and(|filename| {
+            FILE_PREFIXES.iter().any(|x| {
+                filename.starts_with(x) || filename.components().any(|c| c.as_os_str() == ".cargo")
+            })
+        })
     }
 
     /// Heuristically determine whether a frame is likely to be a post panic

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -296,23 +296,17 @@ impl Frame {
         }
 
         const FILE_PREFIXES: &[&str] = &[
-            "/rustc/",
-            "src/libstd/",
-            "src/libpanic_unwind/",
-            "src/libtest/",
+            "/rustc",
+            "src/libstd",
+            "src/libpanic_unwind",
+            "src/libtest",
+            env!("CARGO_HOME"),
         ];
 
         // Inspect filename.
-        if let Some(ref filename) = self.filename {
-            let filename = filename.to_string_lossy();
-            if FILE_PREFIXES.iter().any(|x| filename.starts_with(x))
-                || filename.contains("/.cargo/registry/src/")
-            {
-                return true;
-            }
-        }
-
-        false
+        self.filename
+            .as_deref()
+            .is_some_and(|filename| FILE_PREFIXES.iter().any(|x| filename.starts_with(x)))
     }
 
     /// Heuristically determine whether a frame is likely to be a post panic


### PR DESCRIPTION
The previous check relied on string comparisons, which are not cross-platfom since Windows uses `\` and Unix uses `/`, so on Windows I was always seeing dependencies printed as if they're 1st-party code and couldn't easily filter them out.

Instead of comparing paths as strings, it's better to use `Path::starts_with` which automatically compares paths component-wise regardless of OS delimiter.

I've also changed the 3rd-party dependency check to use CARGO_HOME which is automatically provided by Cargo at build time and allows to precisely check for both dependencies from registries (.../.cargo/registry/src) and git dependencies (.../.cargo/git/checkouts) in one go.

I verified this fixes the issues I've been having with color-backtrace on my Windows project.